### PR TITLE
Removing @author from Java guide.

### DIFF
--- a/code-style/java/javadoc.md
+++ b/code-style/java/javadoc.md
@@ -67,16 +67,7 @@ public void sum(int a, int b) {
 }
 ```
 
-- A tag `@author` sempre deve vir depois de descrição da classe
-
-```java
-/**
- * This is a class.
- *
- * @author author (author at luizalabs.com).
- */
-public class Class {...}
-```
+- A tag `@author` não deve existir já que usamos o git.
 
 - O javadoc deve vir junto ao que ele descrever, **não devem** existir linhas em branco entre o javadoc e o que ele descreve
 


### PR DESCRIPTION
A tag de `@author` é desnecessária considerando que o git já fala quem fez cada linha do código.